### PR TITLE
test: adjust waitUtil assertion

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -236,19 +236,9 @@ test.concurrent('test sync event waitUtil', async () => {
   }
 
   const error = new Error('click')
-
-  const p = divEventProxyAgent
-    .waitUtil('click', {
-      mapToError: () => error,
-      timeout: 500,
-    })
-    .catch(e => {
-      expect(error).toBe(e)
-    })
-
+  const p = divEventProxyAgent.waitUtil('click', { mapToError: () => error, timeout: 500 })
   div.click()
-
-  await p
+  await expect(p).rejects.toBe(error)
 })
 
 test.concurrent('test sync event bind for global', async () => {


### PR DESCRIPTION
## Summary
- refine waitUtil rejection test by awaiting expect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895e855d064832cbfc3dc37b014d7db