### PR TITLE
docs: remove misplaced SyncEvent.new JSDoc

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -185,11 +185,6 @@ export interface ISyncEvent<M extends HandlerMap> {
    * Publisher only allow to call method 'emit'
    */
   get publisher(): Pick<this, 'emit'>
-  /**
-   * Create new SyncEvent
-   * @returns {SyncEvent<M>} 新的 SyncEvent 实例
-   * @static
-   */
 }
 
 export type Arguments<T extends (...args: any) => any> = T extends (...args: infer R) => void


### PR DESCRIPTION
## Summary
- remove stray JSDoc for `SyncEvent.new` from `ISyncEvent`
- ensure `SyncEvent.new` is documented at its implementation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895e7f5879c832cbbaad88e92a8ec04