### PR TITLE
fix: correct variable name in websocket connection

### DIFF
--- a/src/containers/websocket/connection.ts
+++ b/src/containers/websocket/connection.ts
@@ -37,8 +37,8 @@ class WebSocketConnection implements IConnection {
   open = async (): Promise<void> => {
     this.close()
     this.#createWebSocket()
-    const reuslt = await this.#ev.waitUtilRace(['open', 'close'])
-    if (reuslt.event === 'close') {
+    const result = await this.#ev.waitUtilRace(['open', 'close'])
+    if (result.event === 'close') {
       throw new Error('WebSocket connection closed')
     }
   }


### PR DESCRIPTION
## Summary
- fix typo in WebSocketConnection.open method: rename `reuslt` to `result`

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895e7ed1254832ca7ad95318cc2f955