### PR TITLE
fix: cleanup listener configs on offAll

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -101,6 +101,23 @@ test.concurrent('test sync event listenerCount', () => {
   expect(eventEmitter.listenerCount('ev1')).toBe(0)
 })
 
+test('offAll should remove listener options for specific event', () => {
+  jest.useFakeTimers()
+  const eventEmitter = SyncEvent.new<EventHandlerMap>()
+  const handler = jest.fn()
+
+  eventEmitter.on('ev1', handler, { debounce: { waitMs: 50 } })
+  eventEmitter.offAll('ev1')
+
+  eventEmitter.on('ev1', handler)
+  eventEmitter.emit('ev1', '', 1)
+  eventEmitter.emit('ev1', '', 1)
+  jest.advanceTimersByTime(100)
+
+  expect(handler).toHaveBeenCalledTimes(2)
+  jest.useRealTimers()
+})
+
 test.concurrent('test sync event on and once', () => {
   const eventEmitter = SyncEvent.new<EventHandlerMap>()
   let count = 0


### PR DESCRIPTION
## Summary
- clear once handlers and configs when removing all listeners for an event
- ensure off removes listener options to avoid stale debounce/throttle settings
- add regression test for listener option cleanup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689590258104832c8b1082e2e5199e19